### PR TITLE
Rework KaitaiStruct API to be more useful real world, and more conducive to Rust idioms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaitai_struct"
-version = "0.1.0"
+version = "0.2.0"
 authors = [ "Kaitai Contributors" ]
 repository = "https://github.com/kaitai-io/kaitai_struct_rust_runtime"
 homepage = "http://kaitai.io"

--- a/src/kaitai_struct.rs
+++ b/src/kaitai_struct.rs
@@ -2,8 +2,24 @@ use std;
 use kaitai_stream::KaitaiStream;
 
 pub trait KaitaiStruct {
-    fn empty() -> Self where Self : Sized;
-    fn from_file(path: &str) -> std::result::Result<Self, std::io::Error> where Self : Sized;
-    fn new<S: KaitaiStream>(stream: &mut S, parent: &Option<Box<KaitaiStruct>>, root: &Option<Box<KaitaiStruct>>) -> Self where Self : Sized;
-    fn read<S: KaitaiStream>(&mut self, stream: &mut S, parent: &Option<Box<KaitaiStruct>>, root: &Option<Box<KaitaiStruct>>) where Self : Sized;
+    fn from_file(path: &str) -> std::io::Result<Self> where Self : Sized {
+        let mut f = std::fs::File::open(path)?;
+        Self::new(&mut f, &None, &None)
+    }
+    
+    fn from_bytes(bytes: Vec<u8>) -> std::io::Result<Self> where Self : Sized {
+        let mut b = std::io::Cursor::new(bytes);
+        Self::new(&mut b, &None, &None)
+    }
+    
+    fn new<S: KaitaiStream>(stream: &mut S,
+                            parent: &Option<Box<KaitaiStruct>>,
+                            root: &Option<Box<KaitaiStruct>>)
+                            -> std::io::Result<Self>
+        where Self : Sized;
+    
+    fn read<S: KaitaiStream>(&mut self,
+                             stream: &mut S,
+                             parent: &Option<Box<KaitaiStruct>>,
+                             root: &Option<Box<KaitaiStruct>>) -> std::io::Result<()> where Self : Sized;
 }


### PR DESCRIPTION
- empty was removed, as it was not needed
- error handling capabilities were added to all methods
- from_bytes was added, to allow parsing from elsewhere than a file
- from_bytes and from_file were implemented in KaitaiStruct, as the logic is the same regardless of what implements the trait